### PR TITLE
adding transforms for resize and fit photon methods

### DIFF
--- a/php/class-photonfill-transform.php
+++ b/php/class-photonfill-transform.php
@@ -194,6 +194,31 @@ if ( ! class_exists( 'Photonfill_Transform' ) ) {
 				'crop' => '0,' . $horizontal_offset . 'px,100,' . $size['height'],
 			) );
 		}
+
+		/**
+		 * Resize and crop an image to exact width,height pixel dimensions.
+		 */
+		public function resize( $args ) {
+			$size = $this->get_dimensions( $args );
+
+			// return only required args
+			return $this->set_conditional_args( array(
+				'resize' => $size['width'] . ',' . $size['height'],
+			) );
+		}
+
+		/**
+		 * Fit an image to a containing box of width,height dimensions. Image aspect ratio is maintained.
+		 * Image is never cropped.
+		 */
+		public function fit( $args ) {
+			$size = $this->get_dimensions( $args );
+
+			// return only required args
+			return $this->set_conditional_args( array(
+				'fit' => $size['width'] . ',' . $size['height'],
+			) );
+		}
 	}
 }
 


### PR DESCRIPTION
A new transforms to be used as an image callback.

These transforms map to the Photon API [`resize`](https://developer.wordpress.com/docs/photon/api/#resize) and [`fit`](https://developer.wordpress.com/docs/photon/api/#fit) parameters.