### PR TITLE
Prevent a double save on the post and filter before save instead

### DIFF
--- a/photonfill.php
+++ b/photonfill.php
@@ -2,14 +2,14 @@
 /**
  * @package Photonfill
  * @subpackage Plugin
- * @version 0.1.13
+ * @version 0.1.14
  */
 /*
 Plugin Name: Photonfill
 Plugin URI: http://github.com/willgladstone/photonfill
 Description: Integrate Jetpack Photon and Picturefill into WP images
 Author: Will Gladstone
-Version: 0.1.13
+Version: 0.1.14
 Author URI: http://www.alleyinteractive.com/
 */
 

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -112,7 +112,7 @@ if ( ! class_exists( 'Photonfill' ) ) {
 
 				add_filter( 'wp_prepare_attachment_for_js', array( $this, 'prepare_attachment_for_js' ) );
 
-				add_action( 'save_post', array( $this, 'swap_lazyload_classes' ) );
+				add_filter( 'content_save_pre', array( $this, 'swap_lazyload_classes' ), 10, 1 );
 
 				// ensure the required attributes are allowed in the editor
 				add_filter( 'wp_kses_allowed_html', array( $this, 'photonfill_kses_allowed_html' ), 10, 2 );
@@ -779,17 +779,12 @@ if ( ! class_exists( 'Photonfill' ) ) {
 
 		/**
 		 * Swap `lazyloaded` class for `lazyload`. Why is this necessary?
-		 * We need to unveil lazyload images in TinyMCE, which removes the `lazyload` class and adds the `lazyloaded` class. This means on the front end
-		 * lazysizes won't pick up on the image b/c it assumes the image has already been lazyloaded.
-		 * @param int $post_id
+		 * We need to unveil lazyload images in TinyMCE, which removes the `lazyload` class and adds the `lazyloaded` class.
+		 * This means on the front end lazysizes won't pick up on the image b/c it assumes the image has already been lazyloaded.
+		 * @param string $content
 		 */
-		public function swap_lazyload_classes( $post_id ) {
-			$current_post = get_post( $post_id );
-			$current_post->post_content = preg_replace( '/(class="[^"]*)(lazyloaded)([^"]*")/i', '$1' . 'lazyload' . '$3', $current_post->post_content );
-
-			remove_action( 'save_post', array( $this, 'swap_lazyload_classes' ) );
-			wp_update_post( $current_post );
-			add_action( 'save_post', array( $this, 'swap_lazyload_classes' ) );
+		public function swap_lazyload_classes( $content ) {
+			return preg_replace( '/(class=\\\\"[^"]*)(lazyloaded)([^"]*")/i', '$1' . 'lazyload' . '$3', $content );
 		}
 
 		/**


### PR DESCRIPTION
The previous functionality was causing the post to save twice. This will accomplish the same goal (replace the `lazyloaded` class with `lazyload`) but will do it as a filter before the post is saved.