### PR TITLE
Add filter to bypass image downsize hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ PhotonFill also has the option of lazy loading responsive images and allowing th
 * ``photonfill_base_unit_pixel`` If unit specified in breakpoints is `em` what base pixel is the theme. Default (16)
 * ``photonfill_image_sizes`` An image stack of image sizes for corresponding breakpoints.
 * ``photonfill_enable_resize_upload`` Enable/Disable generation of intermediate image sizes. Default (disabled)
-* ``photonfill_picture_class`` Modify the class with a picture element
+* ``photonfill_picture_class`` Modify the class with a picture element.
 * ``photonfill_default_transform`` Set the default transformation for Photon. Default (`Photonfill_Transform::center_crop()`)
 * ``photonfill_use_picture_as_default`` Use a picture element as the default when calling `the_post_thumbnail` or `wp_get_attachment_image`
-
+* ``photonfill_bypass_image_downsize`` Bypass the image downsize hooks which can be problematic on some environments. Set `true` if all of your image URLs are returning the original URL.

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -92,8 +92,8 @@ if ( ! class_exists( 'Photonfill' ) ) {
 			add_filter( 'intermediate_image_sizes_advanced', array( $this, 'disable_image_multi_resize' ) );
 
 			// A hack for the fact that photon doesn't work with wp_ajax calls due to is_admin forcing image downsizing to return the original image
-				// We can also use this hack to bypass the image downsize hooks which can be problematic on VIP Go environments
-				if ( is_admin() || apply_filters( 'photonfill_bypass_image_downsize', false ) ) {
+			// We can also use this hack to bypass the image downsize hooks which can be problematic on some environments
+			if ( is_admin() || apply_filters( 'photonfill_bypass_image_downsize', false ) ) {
 				// Add breakpoint data to image metadata
 				add_filter( 'wp_get_attachment_metadata', array( $this, 'add_image_metadata' ), 20, 2 );
 

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -91,8 +91,9 @@ if ( ! class_exists( 'Photonfill' ) ) {
 			// Disable creating multiple images for newly uploaded images
 			add_filter( 'intermediate_image_sizes_advanced', array( $this, 'disable_image_multi_resize' ) );
 
-			// Allow image sizes to be set when adding content via the modal in the admin area
-			if ( is_admin() ) {
+			// A hack for the fact that photon doesn't work with wp_ajax calls due to is_admin forcing image downsizing to return the original image
+				// We can also use this hack to bypass the image downsize hooks which can be problematic on VIP Go environments
+				if ( is_admin() || apply_filters( 'photonfill_bypass_image_downsize', false ) ) {
 				// Add breakpoint data to image metadata
 				add_filter( 'wp_get_attachment_metadata', array( $this, 'add_image_metadata' ), 20, 2 );
 


### PR DESCRIPTION
Already in use in the admin, this functionality may also be useful on environments which manipulate the way photon works.