### PR TITLE
escape sprintf params as late as possible

### DIFF
--- a/php/class-plugin-dependency.php
+++ b/php/class-plugin-dependency.php
@@ -84,9 +84,9 @@ if ( ! class_exists( "Plugin_Dependency" ) ) {
 			if ( $plugin_file !== false ) {
 				return sprintf(
 					__( '<p style="font-family: sans-serif; font-size: 12px">%s<br>Please <a href="%s" target="_top">activate %s</a> and try again.</p>' ),
-					$this->dependency_message(),
+					esc_html( $this->dependency_message() ),
 					wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin='.$plugin_file ), 'activate-plugin_'.$plugin_file ),
-					$this->dependency_name
+					esc_html( $this->dependency_name )
 				);
 			}
 		}
@@ -108,23 +108,23 @@ if ( ! class_exists( "Plugin_Dependency" ) ) {
 				// The plugin is not available from WordPress.org
 				$install_instructions = sprintf(
 					__( '<br>Please <a href="%s" target="_blank">download and install %s</a> and try again.' ),
-					$this->dependency_uri,
-					$this->dependency_name
+					esc_url( $this->dependency_uri ),
+					esc_html( $this->dependency_name )
 				);
 			} else if ( !is_wp_error( $info ) ) {
 				// The plugin is available from WordPress.org
 				$install_instructions = sprintf(
 					__( '<br>Please <a href="%s" target="_top">install %s</a> and try again.' ),
 					wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=' . $this->slug ), 'install-plugin_' . $this->slug ),
-					$this->dependency_name
+					esc_html( $this->dependency_name )
 				);
 			}
 
 			return sprintf(
 				__( '<p style="font-family: sans-serif; font-size: 12px">%s%s</p>' ),
-				$this->dependency_message(),
+				esc_html( $this->dependency_message() ),
 				$install_instructions
-			);
+			); // $install instructions escaped above.
 		}
 
 		/**
@@ -135,8 +135,8 @@ if ( ! class_exists( "Plugin_Dependency" ) ) {
 		private function dependency_message() {
 			return sprintf(
 				__( '%s requires that %s is installed and active.' ),
-				$this->plugin_name,
-				$this->dependency_name
+				esc_html( $this->plugin_name ),
+				esc_html( $this->dependency_name )
 			);
 		}
 


### PR DESCRIPTION
It may make more sense to kses the message output rather than escaping the parts like this, but this is how VIP asked us to fix it, so this is less likely to trigger flags in future reviews.