### PR TITLE
php7 Fix for indirect method call

### DIFF
--- a/php/class-photonfill-transform.php
+++ b/php/class-photonfill-transform.php
@@ -101,7 +101,7 @@ if ( ! class_exists( 'Photonfill_Transform' ) ) {
 			if ( ! empty( $args['callback'] ) && function_exists( $args['callback'] ) ) {
 				return $args['callback']( $args );
 			} elseif ( ! empty( $args['callback'] ) && method_exists( $this, $args['callback'] ) ) {
-				return $this->$args['callback']( $args );
+				return $this->{$args['callback']}( $args );
 			}
 
 			return $this->default_transform( $args );


### PR DESCRIPTION
Photonfill makes indirect method calls in a way that changes between PHP 5 and PHP 7. This more explicit syntax is compatible with both. http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect