### PR TITLE
Plugin dependency

### DIFF
--- a/photonfill.php
+++ b/photonfill.php
@@ -27,7 +27,7 @@ add_action( 'plugins_loaded', 'photonfill_init' );
 
 function photonfill_dependency() {
 	$photonfill_dependency = new Plugin_Dependency( 'Jetpack', 'Jetpack by WordPress.com', 'http://jetpack.me/' );
-	if ( ! $photonfill_dependency->verify() ) {
+	if ( ! class_exists( 'Jetpack' ) ) {
 		// Cease activation
 	 	die( $photonfill_dependency->message() );
 	}

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -520,7 +520,7 @@ if ( ! class_exists( 'Photonfill' ) ) {
 		 */
 		public function get_lazyload_image( $attachment_id, $size = 'full', $attr = array() ) {
 			$full_src = wp_get_attachment_image_src( $attachment_id, 'full' );
-			$attr['class'][] = 'lazyload';
+			$attr['class'] = 'lazyload';
 			$alt = ( ! empty( $attr['alt'] ) ) ? ' alt=' . esc_attr( $attr['alt'] ) : '';
 			$classes = $this->get_image_classes( $attr['class'], $attachment_id, $size );
 			return '<img data-sizes="auto" data-src="'. esc_url( $full_src[0] ) .'" data-srcset="' . esc_attr( $this->get_responsive_image_attribute( $attachment_id, $size, 'data-srcset' ) ) . '" class="' . esc_attr( $classes ) . '" ' . $alt . '>';


### PR DESCRIPTION
Right now photonfill cannot be activated if Jetpack is installed as an MU plugin, because the plugin dependency checker checks the "active_plugins" option in the database, which doesn't include mu-plugins. So, the activation hook is preventing the plugin from being loaded even if Jetpack actually is active.

This changes to check if the Jetpack class exists instead of checking if it's in the "active_plugins" table, that way it plays nice with mu plugins, not just locally installed plugins.