### PR TITLE
Allow for empty alt tags to be passed as an attribute.

### DIFF
--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -1239,11 +1239,11 @@ if ( ! class_exists( 'Photonfill' ) ) {
 			$attachment = get_post( $attachment_id );
 
 			// First choose image's meta.
-			$alt = trim( strip_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
+			$alt = trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
 
 			// If still empty, try this fallback.
 			if ( empty( $alt ) ) {
-				$alt = trim( strip_tags( $attachment->post_excerpt ) ); // If not, use the caption.
+				$alt = trim( wp_strip_all_tags( $attachment->post_excerpt ) ); // If not, use the caption.
 			}
 
 			// If still empty, set to nothing.

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -100,6 +100,8 @@ if ( ! class_exists( 'Photonfill' ) ) {
 		 */
 		public function setup() {
 			// Set our breakpoints.
+			$this->base_unit_pixel = apply_filters( 'photonfill_base_unit_pixel', $this->base_unit_pixel );
+
 			/**
 			 * A breakpoint can accept the following parameters
 			 *   'max' => int, // Max width of element
@@ -108,8 +110,6 @@ if ( ! class_exists( 'Photonfill' ) ) {
 			 * )
 			 * wp_get_attachment_image does not use pixel density.
 			 */
-			$this->base_unit_pixel = apply_filters( 'photonfill_base_unit_pixel', $this->base_unit_pixel );
-
 			$this->breakpoints = apply_filters( 'photonfill_breakpoints', array(
 				'mobile' => array(
 					'max' => 640,

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -1233,7 +1233,7 @@ if ( ! class_exists( 'Photonfill' ) ) {
 		/**
 		 * Get the alt attribute for image.
 		 *
-		 * @param  int $attachment_id   ID of the attachment
+		 * @param  int $attachment_id   ID of the attachment.
 		 * @return string               Value of alt text
 		 */
 		public function get_alt_text( $attachment_id ) {
@@ -1248,7 +1248,7 @@ if ( ! class_exists( 'Photonfill' ) ) {
 			}
 
 			// If still empty, set to nothing.
-			// For a11y reasons, an empty string is better than the attachment name
+			// For a11y reasons, an empty string is better than the attachment name.
 			if ( empty( $alt ) ) {
 				$alt = '';
 			}

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -102,9 +102,9 @@ if ( ! class_exists( 'Photonfill' ) ) {
 			// Set our breakpoints.
 			/**
 			 * A breakpoint can accept the following parameters
-			 *		'max' => int, // Max width of element
-			 *		'min' => int, // Min width of element
-			 *		'unit' => string, // [px(default),em] Currently does not support vw unit, multi units or calc function.
+			 *   'max' => int, // Max width of element
+			 *   'min' => int, // Min width of element
+			 *   'unit' => string, // [px(default),em] Currently does not support vw unit, multi units or calc function.
 			 * )
 			 * wp_get_attachment_image does not use pixel density.
 			 */
@@ -113,7 +113,7 @@ if ( ! class_exists( 'Photonfill' ) ) {
 			$this->breakpoints = apply_filters( 'photonfill_breakpoints', array(
 				'mobile' => array(
 					'max' => 640,
-				 ),
+				),
 				'mini-tablet' => array(
 					'min' => 640,
 				),

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -1232,8 +1232,8 @@ if ( ! class_exists( 'Photonfill' ) ) {
 
 		/**
 		 * Get the alt attribute for image.
-		 * @param  int $attachment_id ID of the attachment
-		 * @return string                Value of alt text.
+		 * @param  int $attachment_id   ID of the attachment
+		 * @return string               Value of alt text
 		 */
 		public function get_alt_text( $attachment_id ) {
 			$attachment = get_post( $attachment_id );

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -1232,6 +1232,7 @@ if ( ! class_exists( 'Photonfill' ) ) {
 
 		/**
 		 * Get the alt attribute for image.
+		 *
 		 * @param  int $attachment_id   ID of the attachment
 		 * @return string               Value of alt text
 		 */

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -1037,9 +1037,9 @@ if ( ! class_exists( 'Photonfill' ) ) {
 
 			// Update image alt tag if not set.
 			if (
-				! isset( $attr['alt'] ) &&
-				! empty( $attachment_id ) &&
-				is_numeric( $attachment_id )
+				! isset( $attr['alt'] )
+				&& ! empty( $attachment_id )
+				&& is_numeric( $attachment_id )
 			) {
 				$attr['alt'] = $this->get_alt_text( $attachment_id );
 			}

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -1034,19 +1034,16 @@ if ( ! class_exists( 'Photonfill' ) ) {
 		 */
 		private function build_attachment_image( $attachment_id = null, $attr ) {
 			$attr = apply_filters( 'photonfill_img_attributes', $attr, $attachment_id );
-			if ( ! empty( $attachment_id ) && is_numeric( $attachment_id ) ) {
-				$attachment = get_post( $attachment_id );
 
-				if ( empty( $attr['alt'] ) ) {
-					$attr['alt'] = trim( strip_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
-				}
-				if ( empty( $attr['alt'] ) ) {
-					$attr['alt'] = trim( strip_tags( $attachment->post_excerpt ) ); // If not, use the caption.
-				}
-				if ( empty( $attr['alt'] ) ) {
-					$attr['alt'] = ''; // For a11y reasons, an empty string is better than the attachment name.
-				}
+			// Update image alt tag if not set.
+			if (
+				! isset( $attr['alt'] ) &&
+				! empty( $attachment_id ) &&
+				is_numeric( $attachment_id )
+			) {
+				$attr['alt'] = $this->get_alt_text( $attachment_id );
 			}
+
 			$html = '<img ';
 			foreach ( $attr as $key => $value ) {
 				if ( is_bool( $value ) && $value ) {
@@ -1231,6 +1228,31 @@ if ( ! class_exists( 'Photonfill' ) ) {
 			}
 
 			return $allowed;
+		}
+
+		/**
+		 * Get the alt attribute for image.
+		 * @param  int $attachment_id ID of the attachment
+		 * @return string                Value of alt text.
+		 */
+		public function get_alt_text( $attachment_id ) {
+			$attachment = get_post( $attachment_id );
+
+			// First choose image's meta.
+			$alt = trim( strip_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) );
+
+			// If still empty, try this fallback.
+			if ( empty( $alt ) ) {
+				$alt = trim( strip_tags( $attachment->post_excerpt ) ); // If not, use the caption.
+			}
+
+			// If still empty, set to nothing.
+			// For a11y reasons, an empty string is better than the attachment name
+			if ( empty( $alt ) ) {
+				$alt = '';
+			}
+
+			return $alt;
 		}
 
 		/**


### PR DESCRIPTION
This is necessary for a11y as all images should always have an alt tag, but decorative images that are not relevant to the content or call to action should be empty.

From our consultant's report regarding linked images:

> The alternative text for an image which is acting as a link’s label should describe the destination of the link, not the image itself. Similarly, in a button, the alternative text should describe the purpose of the button.
> If an image is only part of a link’s text – for instance, a PDF icon to indicate the link is to a PDF document, then the alternative text should convey this information.
> If a link contains both an image and text, and the text provides all the information required to understand what the link destination is. In this case, the image should be treated as decorative and given an empty or null alt attribute: alt="". This will help to reduce the amount of redundant information that screenreader users encounter.
