### PR TITLE
Set up transformer with dimensions of attachment for JS

### DIFF
--- a/photonfill.php
+++ b/photonfill.php
@@ -9,11 +9,11 @@
 
 /*
 Plugin Name: Photonfill
-Plugin URI: http://github.com/alleyinteractive/photonfill
+Plugin URI: https://github.com/alleyinteractive/photonfill
 Description: Integrate Jetpack Photon and Picturefill into WP images
 Author: Will Gladstone
-Version: 0.2.0
-Author URI: http://www.alleyinteractive.com/
+Version: 0.2.1
+Author URI: https://www.alleyinteractive.com/
 */
 
 /**

--- a/php/class-photonfill-transform.php
+++ b/php/class-photonfill-transform.php
@@ -96,7 +96,7 @@ if ( ! class_exists( 'Photonfill_Transform' ) ) {
 		 * Add in necessary args expected with photonfill
 		 *
 		 * @param array $args Default args for Photon.
-		 * @param array $data New args for Photon.
+		 * @param mixed $data New args for Photon.
 		 * @return array of merged args for Photon.
 		 */
 		public function set_photon_args( $args, $data ) {

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -621,6 +621,12 @@ if ( ! class_exists( 'Photonfill' ) ) {
 
 			if ( ! empty( $attachment['sizes']['medium'] ) ) {
 				$medium_size = $attachment['sizes']['medium'];
+
+				$this->transform->setup( array(
+					'width' => $medium_size['width'],
+					'height' => $medium_size['height'],
+				) );
+
 				$attachment['sizes']['medium']['url'] = $photon_url_function(
 					$medium_size['url'],
 					array(

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -613,8 +613,8 @@ if ( ! class_exists( 'Photonfill' ) ) {
 		/**
 		 * Pass Photon URLs to media browser so it doesn't show full-sized images
 		 *
-		 * @param object $attachment Attachment object.
-		 * @return Attachment object.
+		 * @param array $attachment Attachment object.
+		 * @return array Attachment object.
 		 */
 		public function prepare_attachment_for_js( $attachment ) {
 			$photon_url_function = photonfill_hook_prefix() . '_photon_url';

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -635,7 +635,7 @@ if ( ! class_exists( 'Photonfill' ) ) {
 						'height' => $medium_size['height'],
 					)
 				);
-			} else {
+			} elseif ( ! empty( $attachment['sizes']['full']['url'] ) ) {
 				$attachment['sizes']['medium']['url'] = $photon_url_function(
 					$attachment['sizes']['full']['url'],
 					array(

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -636,12 +636,19 @@ if ( ! class_exists( 'Photonfill' ) ) {
 					)
 				);
 			} elseif ( ! empty( $attachment['sizes']['full']['url'] ) ) {
+				$medium_size = array(
+					'width' => 300,
+					'height' => 225,
+				);
+
+				$this->transform->setup( $medium_size );
+
 				$attachment['sizes']['medium']['url'] = $photon_url_function(
 					$attachment['sizes']['full']['url'],
 					array(
 						'attachment_id' => $attachment['id'],
-						'width' => 300,
-						'height' => 225,
+						'width' => $medium_size['width'],
+						'height' => $medium_size['height'],
 					)
 				);
 			}


### PR DESCRIPTION
Without `setup()`, `Photonfill_Transform::$args` will be empty when `Photonfill_Transform:: set_photon_args()` runs. 

`$args['width']` and `$args['height']` will then be set to `$data['width']` and `$data['height']`, but `$data` can be the string URL of the attachment, which mangles `$args`.