### PR TITLE
Add vipgo-helper.php and wpcom-helper.php files

### DIFF
--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -1,0 +1,11 @@
+<?php
+/*
+ * Helper file which gets included during the `wpcom_vip_load_plugin` activation
+ * from theme's functions.php on the VIP Go platform.
+ */
+
+/*
+ * Call photonfill_init function manually, as it was supposed to get called
+ * on plugins_loaded hook, which already fired before we included plugin's files.
+ */
+photonfill_init();

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -1,0 +1,11 @@
+<?php
+/*
+ * Helper file which gets included during the `wpcom_vip_load_plugin` activation
+ * from theme's functions.php on the WordPress.com VIP platform.
+ */
+
+/*
+ * Call photonfill_init function manually, as it was supposed to get called
+ * on plugins_loaded hook, which already fired before we included plugin's files.
+ */
+photonfill_init();


### PR DESCRIPTION
As on the WordPress.com VIP and VIP Go platforms the recommended way for activating a plugin is via theme's functions.php, the `photonfill_init` function hooked to `plugins_loaded` does not get triggered, as it's too late when the plugin files get included.

The wpcom-helper.php and vipgo-helper.php files get included right after the plugin gets loaded via `wpcom_vip_load_plugin`.

The files currently contain only the call to `photonfill_init()` function for properly setting up the plugin.
