### PR TITLE
Handle query string datatype supported by Core

### DIFF
--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -847,11 +847,11 @@ if ( ! class_exists( 'Photonfill' ) ) {
 		/**
 		 * Alter the_post_thumbnail html.
 		 *
-		 * @param string $html Markup for image.
-		 * @param int    $post_id Post id.
-		 * @param int    $post_thumbnail_id Post thumbnail image id.
-		 * @param string $size Image size.
-		 * @param array  $attr Image attributes.
+		 * @param string       $html Markup for image.
+		 * @param int          $post_id Post id.
+		 * @param int          $post_thumbnail_id Post thumbnail image id.
+		 * @param string       $size Image size.
+		 * @param array|string $attr Image attributes.
 		 * @return string Image markup.
 		 */
 		public function get_picturefill_html( $html, $post_id, $post_thumbnail_id, $size, $attr ) {

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -855,6 +855,16 @@ if ( ! class_exists( 'Photonfill' ) ) {
 		 * @return string Image markup.
 		 */
 		public function get_picturefill_html( $html, $post_id, $post_thumbnail_id, $size, $attr ) {
+			// Core permits $attr to be a query string or an array, but Photonfill expects an array.
+			if ( ! is_array( $attr ) ) {
+				$original = $attr;
+				$attr = array();
+
+				if ( is_string( $original ) && ! empty( $original ) ) {
+					wp_parse_str( $original, $attr );
+				}
+			}
+
 			if ( apply_filters( 'photonfill_use_picture_as_default', false ) ) {
 				return $this->get_attachment_picture( $post_thumbnail_id, $size, $attr );
 			} else {
@@ -917,7 +927,7 @@ if ( ! class_exists( 'Photonfill' ) ) {
 				}
 				return $html;
 			}
-			return;
+			return '';
 		}
 
 		/**


### PR DESCRIPTION
When calling `get_the_post_thumbnail()`, attributes can be specified as an array or a query string, but Photonfill assumes an array in its `post_thumbnail_html` callback.