### PR TITLE
Resolve ArgumentCountError warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ before_script:
       composer global require "phpunit/phpunit=4.8.*"
     fi
   - |
-    composer global require wp-coding-standards/wpcs
-    phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+    composer global require automattic/vipwpcs
+    phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs,$HOME/.composer/vendor/automattic/vipwpcs
 
 script:
   - phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -693,15 +693,12 @@ if ( ! class_exists( 'Photonfill' ) ) {
 		 */
 		function ajax_get_img_object() {
 			check_ajax_referer( 'photonfill_get_img_object', 'nonce' );
-			// Disable PHPCS warning on inspecting super global.
-			// @codingStandardsIgnoreStart
 			if ( ! empty( $_POST['attachment'] ) ) {
 				$attachment_id = absint( $_POST['attachment'] );
-				echo wp_kses( $this->get_attachment_image( $attachment_id, 'full', array(
+				echo wp_kses_post( $this->get_attachment_image( $attachment_id, 'full', array(
 					'style' => 'max-width:100%',
 				) ) );
 			}
-			// @codingStandardsIgnoreEnd
 			exit();
 		}
 

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -691,7 +691,7 @@ if ( ! class_exists( 'Photonfill' ) ) {
 		 *
 		 * @return void Echos image markup.
 		 */
-		function ajax_get_img_object() {
+		public function ajax_get_img_object() {
 			check_ajax_referer( 'photonfill_get_img_object', 'nonce' );
 			if ( ! empty( $_POST['attachment'] ) ) {
 				$attachment_id = absint( $_POST['attachment'] );
@@ -711,7 +711,7 @@ if ( ! class_exists( 'Photonfill' ) ) {
 		 * @param string $value Current field value (not used).
 		 * @param object $attachment Attachment object.
 		 */
-		function set_fieldmanager_media( $preview, $value, $attachment ) {
+		public function set_fieldmanager_media( $preview, $value, $attachment ) {
 			if ( ! empty( $attachment->ID ) && strpos( $attachment->post_mime_type, 'image/' ) === 0 ) {
 				$preview = esc_html__( 'Uploaded image:', 'photonfill' ) . '<br />';
 				$preview .= '<a href="#">' . $this->get_attachment_image( $attachment->ID, 'full', array(

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -2,9 +2,8 @@
 <ruleset name="WordPress Coding Standards for Plugins">
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
-	<rule ref="WordPress-Core" />
-	<rule ref="WordPress-VIP" />
-	<rule ref="WordPress-Docs" />
+	<rule ref="WordPress" />
+	<rule ref="WordPressVIPMinimum" />
 
 	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>


### PR DESCRIPTION
`wp_kses()` expects at least two arguments, but context indicates `wp_kses_post()` was likely the intended function call, as this callback is used for Fieldmanager media fields.

Fixes #93