### PR TITLE
BR-2190 Fix src domain issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/photonfill.php
+++ b/photonfill.php
@@ -4,7 +4,7 @@
  *
  * @package Photonfill
  * @subpackage Plugin
- * @version 0.2.0
+ * @version 0.2.2
  */
 
 /*
@@ -12,7 +12,7 @@ Plugin Name: Photonfill
 Plugin URI: https://github.com/alleyinteractive/photonfill
 Description: Integrate Jetpack Photon and Picturefill into WP images
 Author: Will Gladstone
-Version: 0.2.1
+Version: 0.2.2
 Author URI: https://www.alleyinteractive.com/
 */
 

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -351,6 +351,9 @@ if ( ! class_exists( 'Photonfill' ) ) {
 			if ( ! empty( $attachment->ID ) ) {
 				$image = $this->create_image_object( $attachment->ID, $size );
 				if ( ! empty( $image['id'] ) ) {
+					if ( isset( $attr['src'] ) && ! is_feed() && photonfill_use_lazyload() ) {
+						unset( $attr['src'] );
+					}
 					$srcset = array();
 					$sizes = array();
 

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -1059,13 +1059,17 @@ if ( ! class_exists( 'Photonfill' ) ) {
 				$attr['alt'] = $this->get_alt_text( $attachment_id );
 			}
 
-			// Update image src attribute if not set.
+			// Update image src attribute if not set and if lazyload is not requested.
 			if (
-				! isset( $attr['src'] )
+				isset( $attr['src'] )
 				&& ! empty( $attachment_id )
 				&& is_numeric( $attachment_id )
+				&& ( ! photonfill_use_lazyload() || is_feed() )
 			) {
-				$attr['src'] = wp_get_attachment_url( $attachment_id );
+				$img_src = $this->get_img_src( $attachment_id );
+				if ( ! empty( $img_src['url'] ) ) {
+					$attr['src'] = $img_src['url'];
+				}
 			}
 
 			$html = '<img ';

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -1063,8 +1063,7 @@ if ( ! class_exists( 'Photonfill' ) ) {
 			}
 
 			// Update image src attribute if not set and if lazyload is not requested.
-			if (
-				isset( $attr['src'] )
+			if ( ! isset( $attr['src'] )
 				&& ! empty( $attachment_id )
 				&& is_numeric( $attachment_id )
 				&& ( ! photonfill_use_lazyload() || is_feed() )


### PR DESCRIPTION
* Modifies the `src` attribute when lazyloading to use a small, low-resolution version of the image as a placeholder.
* Ensures that the `src` attribute is using the correct Photon-ized URL by dissecting `srcset`.
* Bumps version number to account for these changes.