### PR TITLE
Ensuring `$new_tag` isn't empty before `str_replace` 

### DIFF
--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -1390,7 +1390,9 @@ if ( ! class_exists( 'Photonfill' ) ) {
 
 						remove_filter( 'photonfill_default_transform', array( $this, 'set_inline_content_default_transform' ) );
 
-						$the_content = str_replace( $images['img_tag'][ $index ], $new_tag, $the_content );
+						if ( ! empty( $new_tag ) ) {
+							$the_content = str_replace( $images['img_tag'][ $index ], $new_tag, $the_content );
+						}
 					}
 				} // End foreach().
 			} // End if().


### PR DESCRIPTION
If content is copied over from another WordPress site, it will still have the `wp-image-*` class on images, but the `attachment_id` they reference will be invalid. 

Lines `1376-1380` will attempt to find said image, but ultimately result in an empty `$new_tag` variable. 

Without the simple check below, this results in the `str_replace` function effectively wiping out all images in the content!

