### PR TITLE
Bail if Jetpack Photon or My Photon isn't loaded

### DIFF
--- a/photonfill.php
+++ b/photonfill.php
@@ -135,6 +135,13 @@ function photonfill_use_lazyload() {
  * @return bool
  */
 function photonfill_is_enabled() {
+	// Bail if Jetpack Photon or My Photon isn't loaded
+	$class = ucfirst( photonfill_hook_prefix() ) . '_Photon';
+
+	if ( ! class_exists( $class ) ) {
+		return false;
+	}
+
 	return apply_filters( 'photonfill_enabled', true );
 }
 


### PR DESCRIPTION
If Jetpack is deactivated, but Photonfill is still active -- then photonfill can result in a Fatal Error that breaks the front-end if this site. 

This adds a check to make sure that Jetpack (or My Photon) is actually enabled. 