### PR TITLE
Easy Skipping LazyLoad By Image

### DIFF
--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -989,8 +989,14 @@ if ( ! class_exists( 'Photonfill' ) ) {
 			$src = explode( ' ', $sources[0] );
 
 			$attr['data-sizes'] = 'auto';
-			$attr['data-src'] = $src[0];
-			$attr['data-srcset'] = $srcset;
+			
+			if ( ! in_array( 'skip-lazy', $attr['class'] ) ) {
+				$attr['data-srcset'] = $srcset;
+				$attr['data-src'] = $src[0];
+			} else {
+				$attr['srcset'] = $srcset;
+			}
+			
 			$attr['class'] = $this->get_image_classes( $attr['class'], $attachment_id, $size );
 
 			return $this->build_attachment_image( $attachment_id, $attr );

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -973,6 +973,11 @@ if ( ! class_exists( 'Photonfill' ) ) {
 		 * @return string Image markup.
 		 */
 		public function get_lazyload_image( $attachment_id, $size = 'full', $attr = array() ) {
+			$lazyload_disable = false;
+			if ( array_key_exists( 'class', $attr ) && false !== strpos( $attr['class'], 'skip-lazy' ) ) {
+				$lazyload_disable = true;
+			}
+			
 			if ( empty( $attr['class'] ) ) {
 				$attr['class'] = array( 'lazyload' );
 			} else {
@@ -980,7 +985,7 @@ if ( ! class_exists( 'Photonfill' ) ) {
 					$attr['class'] = explode( ' ', $attr['class'] );
 				}
 				
-				if ( ! in_array( 'skip-lazy' , $attr['class'] ) ) {
+				if ( false === $lazyload_disable ) {
 					$attr['class'][] = 'lazyload';
 				}
 			}
@@ -990,9 +995,9 @@ if ( ! class_exists( 'Photonfill' ) ) {
 
 			$attr['data-sizes'] = 'auto';
 			
-			if ( ! in_array( 'skip-lazy', $attr['class'] ) ) {
+			if ( false === $lazyload_disable ) {
+				$attr['data-src']    = $src[0];
 				$attr['data-srcset'] = $srcset;
-				$attr['data-src'] = $src[0];
 			} else {
 				$attr['srcset'] = $srcset;
 			}

--- a/php/class-photonfill.php
+++ b/php/class-photonfill.php
@@ -979,7 +979,10 @@ if ( ! class_exists( 'Photonfill' ) ) {
 				if ( ! is_array( $attr['class'] ) ) {
 					$attr['class'] = explode( ' ', $attr['class'] );
 				}
-				$attr['class'][] = 'lazyload';
+				
+				if ( ! in_array( 'skip-lazy' , $attr['class'] ) ) {
+					$attr['class'][] = 'lazyload';
+				}
 			}
 			$srcset = $this->get_responsive_image_attribute( $attachment_id, $size, 'data-srcset' );
 			$sources = explode( ',', $srcset );


### PR DESCRIPTION
Allow the user to easily disable lazy-loading for an image but still keep rest of photon functionality by passing the 'skip-lazy' class into a 'class' array of the $attr variable.